### PR TITLE
Create a local copy of 'type' in the parser

### DIFF
--- a/pb/proto/parser.lua
+++ b/pb/proto/parser.lua
@@ -22,6 +22,7 @@ local lower = string.lower
 local tremove = table.remove
 local tsort = table.sort
 local assert = assert
+local type = type
 
 local mod_path = string.match(...,".*%.") or ''
 


### PR DESCRIPTION
When reading a protobuf message with only one field, I get the following error (Lua 5.2):

  pb/proto/parser.lua:82: attempt to call global 'type' (a nil value)

Making a local copy of function type in the parser fixes the problem.
