### PR TITLE
included "pb/standard/zigzag.lua" to rockspec

### DIFF
--- a/lua-pb-scm-0.rockspec
+++ b/lua-pb-scm-0.rockspec
@@ -38,6 +38,7 @@ build	= {
 			['pb.standard.buffer']  = "pb/standard/buffer.lua",
 			['pb.standard.unknown'] = "pb/standard/unknown.lua",
 			['pb.standard.dump']    = "pb/standard/dump.lua",
+			['pb.standard.zigzag']  = "pb/standard/zigzag.lua",
 		}
 	}
 }


### PR DESCRIPTION
This change will fix - module 'pb.standard.zigzag' not found error